### PR TITLE
Fix wrong midi channel pitch value.

### DIFF
--- a/Midi/MidiContext.cs
+++ b/Midi/MidiContext.cs
@@ -134,8 +134,8 @@
 					Channels[cn].Controls[mw.Data1] = mw.Data2;
 					break;
 				case 0xE0:
-					mw = message as MidiMessageWord;
-					Channels[cn].PitchWheel = mw.Data;
+					var mcp = message as MidiMessageChannelPitch;
+					Channels[cn].PitchWheel = mcp.Pitch;
 					break;
 				case 0xF0:
 					switch(RunningStatus & 0xF)

--- a/Midi/MidiMessage.cs
+++ b/Midi/MidiMessage.cs
@@ -1365,7 +1365,7 @@
 		/// <summary>
 		/// Creates a new MIDI channel pitch message
 		/// </summary>
-		/// <param name="pitch">The MIDI pressure (0-16383)</param>
+		/// <param name="pitch">The MIDI pitch (0-16383)</param>
 		/// <param name="channel">The MIDI channel (0-15)</param>
 		public MidiMessageChannelPitch(short pitch, byte channel) : base(unchecked((byte)(0xE0 | channel)), BitConverter.IsLittleEndian?MidiUtility.Swap(pitch):pitch)
 		{
@@ -1380,9 +1380,7 @@
 		/// </summary>
 		public short Pitch {
 			get {
-				if (BitConverter.IsLittleEndian)
-					return MidiUtility.Swap(Data);
-				return Data;
+				return unchecked((short)(Data1 + Data2 * 128));
 			}
 		}
 		/// <summary>


### PR DESCRIPTION
Midi channel pitch must be a 14bit value from 0-16383. 
Current implementation is 15bit value from 0-32639.

Current implementation just combines the two bytes to a 15bit value with a leading 0. 
`unchecked((short)(Data1 + Data2 * 256))` leads to a range from 0 to (127 + 127 * 256) =  32639.    01111111 01111111

Correct calculation for 14bit value:
`unchecked((short)(Data1 + Data2 * 128))` leads to a range from 0 to (127 + 127 * 128) =  16383.    01111111 1111111

Also when calculated like that, endianess is already always correct.
